### PR TITLE
Adds advanced exam examples and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Kaj Kowalski
+Copyright (c) 2025 Kaj Kowalski
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Kaj Kowalski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,5 +1,4 @@
 README.md
-setup.py
 mkdocs_exam/plugin.py
 mkdocs_exam/css/exam.css
 mkdocs_exam/js/exam.js

--- a/README.md
+++ b/README.md
@@ -78,3 +78,7 @@ You can disable the exam for a page by adding the following to the top (meta) of
 exam: disable
 ---
 ```
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/example/docs/advanced.md
+++ b/example/docs/advanced.md
@@ -1,0 +1,29 @@
+# Advanced Exam Features
+
+The following examples demonstrate advanced usage of the `mkdocs-exam` plugin.
+
+## Multiple correct answers
+
+<exam>
+question: Select the <strong>prime</strong> numbers.
+answer-correct: 2
+answer-correct: 3
+answer: 4
+answer-correct: 5
+content:
+
+<p>Multiple answers may be correct in this question.</p>
+</exam>
+
+## HTML in questions and answers
+
+<exam>
+question: What does the <code>&lt;br&gt;</code> tag do?
+answer-correct: Inserts a line break
+answer: <em>Makes text bold</em>
+answer: Creates a hyperlink
+content:
+
+<p>The <code>br</code> element simply causes a line break in the rendered page.</p>
+</exam>
+

--- a/example/mkdocs.yml
+++ b/example/mkdocs.yml
@@ -11,6 +11,11 @@ edit_uri: edit/master/docs/
 
 dev_addr: localhost:8008
 
+nav:
+  - Home: index.md
+  - Disabled Exam: disable.md
+  - Advanced: advanced.md
+
 theme:
   name: material
   language: en


### PR DESCRIPTION
Introduces advanced usage examples for the exam plugin, including support for multiple correct answers and HTML elements in questions and answers. Updates documentation navigation to include new examples.

Formalizes the project's open-source status by adding an MIT License and updating the README with licensing information. Removes unnecessary references from the project manifest.

These changes enhance documentation clarity and legal compliance, offering users broader functionality and clear usage guidelines. 

Fixes #17, #15, #16