### PR TITLE
Add drag and drop exam type

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,20 @@ content:
 </exam>
 ```
 
+### Drag and drop
+
+Move each item to the correct target.
+
+```markdown
+<drag>
+question: Match the capitals.
+pair: Berlin -> Germany
+pair: Madrid -> Spain
+content:
+<p>The capitals belong to their countries.</p>
+</drag>
+```
+
 ## [Demo](https://kjanat.github.io/mkdocs-exam/)
 
 ## Screenshots

--- a/example/docs/advanced.md
+++ b/example/docs/advanced.md
@@ -26,3 +26,14 @@ content:
 
 <p>The <code>br</code> element simply causes a line break in the rendered page.</p>
 </exam>
+
+## Drag and drop
+
+<drag>
+question: Match the capitals.
+pair: Berlin -> Germany
+pair: Madrid -> Spain
+content:
+
+<p>Drag each capital onto the correct country.</p>
+</drag>

--- a/mkdocs_exam/css/exam.css
+++ b/mkdocs_exam/css/exam.css
@@ -56,3 +56,32 @@ input[type="radio"].wrong {
 .content {
   margin: 10px;
 }
+
+/* Drag-and-drop exams */
+.drag-container,
+.drop-container {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}
+.drag-item {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  cursor: grab;
+  background-color: var(--md-default-bg-color);
+}
+.drop-zone {
+  min-width: 4rem;
+  min-height: 2rem;
+  border: 2px dashed #ccc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.drop-zone.wrong {
+  border-color: red;
+}
+.drop-zone.correct {
+  border-color: green;
+}

--- a/mkdocs_exam/js/exam.js
+++ b/mkdocs_exam/js/exam.js
@@ -45,6 +45,52 @@ document.querySelectorAll('.exam').forEach((exam) => {
   })
 })
 
+// Drag-and-drop exams
+document.querySelectorAll('.drag-exam').forEach((exam) => {
+  const form = exam.querySelector('form')
+  let dragged = null
+  exam.querySelectorAll('.drag-item').forEach((item) => {
+    item.addEventListener('dragstart', () => {
+      dragged = item
+    })
+  })
+  exam.querySelectorAll('.drop-zone').forEach((zone) => {
+    zone.addEventListener('dragover', (e) => {
+      e.preventDefault()
+    })
+    zone.addEventListener('drop', (e) => {
+      e.preventDefault()
+      if (dragged) {
+        zone.innerHTML = ''
+        zone.appendChild(dragged)
+        dragged = null
+      }
+    })
+  })
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault()
+    let isCorrect = true
+    exam.querySelectorAll('.drop-zone').forEach((zone) => {
+      zone.classList.remove('wrong')
+      zone.classList.remove('correct')
+      const item = zone.querySelector('.drag-item')
+      if (!item || item.dataset.id !== zone.dataset.target) {
+        isCorrect = false
+        zone.classList.add('wrong')
+      } else {
+        zone.classList.add('correct')
+      }
+    })
+    const section = exam.querySelector('section')
+    if (isCorrect) {
+      section.classList.remove('hidden')
+    } else {
+      section.classList.add('hidden')
+    }
+  })
+})
+
 function resetFieldset (fieldset) {
   const fieldsetChildren = fieldset.children
   for (let i = 0; i < fieldsetChildren.length; i++) {

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -60,3 +60,34 @@ def test_exam_disabled_leaves_markdown_unchanged():
     page = DummyPage(meta={"exam": "disable"})
     result = plugin.on_page_markdown(markdown, page, None)
     assert result == markdown
+
+
+def test_drag_exam_block_converts_to_html():
+    markdown = textwrap.dedent(
+        """
+        <drag>
+
+        question: Match
+        pair: A -> 1
+        pair: B -> 2
+        content:
+
+        <p>Hi</p>
+        </drag>
+        """
+    )
+    plugin = MkDocsExamPlugin()
+    result = plugin.on_page_markdown(markdown, DummyPage(), None)
+    expected = (
+        "\n"
+        '<div class="drag-exam"><h3>Match</h3><form><div class="drag-container">'
+        '<div class="drag-item" draggable="true" data-id="drag-0-0">A</div>'
+        '<div class="drag-item" draggable="true" data-id="drag-0-1">B</div>'
+        '</div><div class="drop-container">'
+        '<div class="drop-zone" data-target="drag-0-0">1</div>'
+        '<div class="drop-zone" data-target="drag-0-1">2</div>'
+        '</div><button type="submit" class="exam-button">Submit</button>'
+        '</form><section class="content hidden">\n'
+        "<p>Hi</p></section></div>\n"
+    )
+    assert result == expected


### PR DESCRIPTION
## Summary
- extend plugin to parse `<drag>` blocks
- add JS and CSS for drag-and-drop functionality
- document drag exam in README and advanced example
- test drag exam

## Testing
- `pre-commit run --files README.md example/docs/advanced.md mkdocs_exam/css/exam.css mkdocs_exam/js/exam.js mkdocs_exam/plugin.py tests/test_plugin.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a228da0108320b11a62dcb43e7044