### PR TITLE
Add more exam question types

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,34 @@ content:
 </exam>
 ```
 
+### Short answer
+
+Provide the expected answer as `answer-correct` and set the type to `short-answer`:
+
+```markdown
+<exam>
+type: short-answer
+question: What color is the sky?
+answer-correct: blue
+content:
+<p>The sky often appears blue due to Rayleigh scattering.</p>
+</exam>
+```
+
+### Fill in the blank
+
+Use three underscores (`___`) as placeholder in your question and provide the correct answer.
+
+```markdown
+<exam>
+type: fill
+question: 2 + 2 = ___
+answer-correct: 4
+content:
+<p>A simple addition problem.</p>
+</exam>
+```
+
 ## [Demo](https://kjanat.github.io/mkdocs-exam/)
 
 ## Screenshots

--- a/example/docs/advanced.md
+++ b/example/docs/advanced.md
@@ -26,3 +26,25 @@ content:
 
 <p>The <code>br</code> element simply causes a line break in the rendered page.</p>
 </exam>
+
+## Short answer
+
+<exam>
+type: short-answer
+question: Who wrote "1984"?
+answer-correct: George Orwell
+content:
+
+<p>The novel "1984" was written by George Orwell.</p>
+</exam>
+
+## Fill in the blank
+
+<exam>
+type: fill
+question: The capital of France is ___
+answer-correct: Paris
+content:
+
+<p>Paris is the capital city of France.</p>
+</exam>

--- a/mkdocs_exam/css/exam.css
+++ b/mkdocs_exam/css/exam.css
@@ -53,6 +53,12 @@ input[type="radio"].correct {
 input[type="radio"].wrong {
   accent-color: red;
 }
+.exam input[type="text"].correct {
+  border: 2px solid green;
+}
+.exam input[type="text"].wrong {
+  border: 2px solid red;
+}
 .content {
   margin: 10px;
 }

--- a/mkdocs_exam/js/exam.js
+++ b/mkdocs_exam/js/exam.js
@@ -1,54 +1,65 @@
 document.querySelectorAll('.exam').forEach((exam) => {
   const form = exam.querySelector('form')
   const fieldset = form.querySelector('fieldset')
+  const type = exam.dataset.type || 'choice'
   form.addEventListener('submit', (event) => {
     event.preventDefault()
-    const selectedAnswers = form.querySelectorAll(
-      'input[name="answer"]:checked'
-    )
-    const correctAnswers = fieldset.querySelectorAll(
-      'input[name="answer"][correct]'
-    )
-    // Check if all correct answers are selected
-    let isCorrect = selectedAnswers.length === correctAnswers.length
-    for (let i = 0; i < selectedAnswers.length; i++) {
-      if (!selectedAnswers[i].hasAttribute('correct')) {
-        isCorrect = false
-        break
+    let isCorrect = false
+
+    if (type === 'choice') {
+      const selected = form.querySelectorAll('input[name="answer"]:checked')
+      const correct = fieldset.querySelectorAll('input[name="answer"][correct]')
+      isCorrect = selected.length === correct.length
+      for (let i = 0; i < selected.length; i++) {
+        if (!selected[i].hasAttribute('correct')) {
+          isCorrect = false
+          break
+        }
+      }
+      markFields(selected, isCorrect)
+    } else {
+      const inputs = fieldset.querySelectorAll('input[type="text"][name="answer"]')
+      isCorrect = true
+      for (let i = 0; i < inputs.length; i++) {
+        const expected = (inputs[i].getAttribute('correct') || '').split('|')
+        const val = inputs[i].value.trim().toLowerCase()
+        const ok = expected.map((e) => e.trim().toLowerCase()).includes(val)
+        if (!ok) {
+          isCorrect = false
+        }
+        inputs[i].classList.add(ok ? 'correct' : 'wrong')
       }
     }
+
     const section = exam.querySelector('section')
     if (isCorrect) {
       section.classList.remove('hidden')
-      resetFieldset(fieldset)
-      // Mark all fields with colors
-      const allAnswers = fieldset.querySelectorAll('input[name="answer"]')
-      for (let i = 0; i < allAnswers.length; i++) {
-        if (allAnswers[i].hasAttribute('correct')) {
-          allAnswers[i].parentElement.classList.add('correct')
-        } else {
-          allAnswers[i].parentElement.classList.add('wrong')
-        }
-      }
     } else {
       section.classList.add('hidden')
-      resetFieldset(fieldset)
-      // Mark wrong fields with colors
-      for (let i = 0; i < selectedAnswers.length; i++) {
-        if (!selectedAnswers[i].hasAttribute('correct')) {
-          selectedAnswers[i].parentElement.classList.add('wrong')
-        } else {
-          selectedAnswers[i].parentElement.classList.add('correct')
-        }
-      }
     }
   })
 })
+
+function markFields (selected, correct) {
+  resetFieldset(selected[0].closest('fieldset'))
+  for (let i = 0; i < selected.length; i++) {
+    if (!selected[i].hasAttribute('correct')) {
+      selected[i].parentElement.classList.add('wrong')
+    } else {
+      selected[i].parentElement.classList.add('correct')
+    }
+  }
+}
 
 function resetFieldset (fieldset) {
   const fieldsetChildren = fieldset.children
   for (let i = 0; i < fieldsetChildren.length; i++) {
     fieldsetChildren[i].classList.remove('wrong')
     fieldsetChildren[i].classList.remove('correct')
+    const input = fieldsetChildren[i].querySelector('input')
+    if (input) {
+      input.classList.remove('wrong')
+      input.classList.remove('correct')
+    }
   }
 }

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -27,16 +27,63 @@ def test_exam_block_converts_to_html():
     result = plugin.on_page_markdown(markdown, DummyPage(), None)
     expected = (
         "\n"
-        '<div class="exam"><h3>Are you ready?</h3><form><fieldset>'
-        '<div><input type="radio" name="answer" value="0" id="exam-0-0" correct>'
-        '<label for="exam-0-0">Yes!</label></div>'
-        '<div><input type="radio" name="answer" value="1" id="exam-0-1" >'
-        '<label for="exam-0-1">No!</label></div>'
-        '<div><input type="radio" name="answer" value="2" id="exam-0-2" >'
-        '<label for="exam-0-2">Maybe!</label></div>'
+        '<div class="exam" data-type="choice"><h3>Are you ready?</h3><form><fieldset>'
+        '<div><input type="radio" name="answer" value="0" id="exam-0-0" correct><label for="exam-0-0">Yes!</label></div>'
+        '<div><input type="radio" name="answer" value="1" id="exam-0-1" ><label for="exam-0-1">No!</label></div>'
+        '<div><input type="radio" name="answer" value="2" id="exam-0-2" ><label for="exam-0-2">Maybe!</label></div>'
         '</fieldset><button type="submit" class="exam-button">Submit</button>'
-        '</form><section class="content hidden">\n'
-        "<h2>Provide some additional content</h2></section></div>\n"
+        '</form><section class="content hidden"><h2>Provide some additional content</h2></section></div>\n'
+    )
+    assert result == expected
+
+
+def test_short_answer_question():
+    markdown = textwrap.dedent(
+        """
+        <exam>
+
+        type: short-answer
+        question: What color is the sky?
+        answer-correct: blue
+        content:
+
+        <p>It is often blue.</p>
+        </exam>
+        """
+    )
+    plugin = MkDocsExamPlugin()
+    result = plugin.on_page_markdown(markdown, DummyPage(), None)
+    expected = (
+        "\n"
+        '<div class="exam" data-type="short-answer"><h3>What color is the sky?</h3><form><fieldset>'
+        '<div><input type="text" name="answer" correct="blue" ></div>'
+        '</fieldset><button type="submit" class="exam-button">Submit</button>'
+        '</form><section class="content hidden"><p>It is often blue.</p></section></div>\n'
+    )
+    assert result == expected
+
+
+def test_fill_question():
+    markdown = textwrap.dedent(
+        """
+        <exam>
+
+        type: fill
+        question: 2 + 2 = ___
+        answer-correct: 4
+        content:
+
+        <p>Easy math.</p>
+        </exam>
+        """
+    )
+    plugin = MkDocsExamPlugin()
+    result = plugin.on_page_markdown(markdown, DummyPage(), None)
+    expected = (
+        "\n"
+        '<div class="exam" data-type="fill"><h3>2 + 2 = <input type="text" name="answer" correct="4"></h3><form><fieldset>'
+        '</fieldset><button type="submit" class="exam-button">Submit</button>'
+        '</form><section class="content hidden"><p>Easy math.</p></section></div>\n'
     )
     assert result == expected
 


### PR DESCRIPTION
## Summary
- support `short-answer` and `fill` question types in `MkDocsExamPlugin`
- handle new question types in JS and CSS
- document the new syntax
- add examples and tests for the extra question types

## Testing
- `pytest -q`
- `npx --yes standard --fix mkdocs_exam/js/exam.js`

------
https://chatgpt.com/codex/tasks/task_e_684a2531a9708320aaafd9015a8ee508